### PR TITLE
Limit feed length

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.includes(:user).order(played_at: :desc, id: :desc)
+      scores = Score.all.includes(:user).limit(25).order(played_at: :desc, id: :desc)
       serialized_scores = scores.map(&:serialize)
 
       response = {

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,11 +29,11 @@ User.create!(
 rng = Random.new
 now = Time.zone.today
 User.all.each do |user|
-  5.times do |i|
+  10.times do |i|
     Score.create!(
       user: user,
       total_score: rng.rand(66..99),
-      played_at: now - 5.days + i.days
+      played_at: now - 10.days + i.days
     )
   end
 end

--- a/spec/controllers/api/scores_controller_spec.rb
+++ b/spec/controllers/api/scores_controller_spec.rb
@@ -26,6 +26,19 @@ describe Api::ScoresController, type: :request do
       expect(scores[1]['total_score']).to eq 68
       expect(scores[2]['total_score']).to eq 79
     end
+
+    it 'should limit feed length to 25' do
+      30.times do
+        create(:score, user: @user1, total_score: 101, played_at: '2021-07-15')
+      end
+      get api_feed_path
+
+      expect(response).to have_http_status(:ok)
+      response_hash = JSON.parse(response.body)
+      scores = response_hash['scores']
+
+      expect(scores.size).to eq 25
+    end
   end
 
   describe 'POST create' do


### PR DESCRIPTION
Fixes:[ issue url
](https://github.com/GeorgeMarcus/golfr_backend/issues/21)
**Changes**

Add `.limit(25)` to scores querry 
Add test for checking `scores.size`
Change `db/seed.rb` to add 30 scores

**Before**
<img width="1299" alt="Screenshot 2022-06-21 at 11 56 08" src="https://user-images.githubusercontent.com/106440100/174763580-46db4db0-0d5f-4b4f-a7e5-ae1a67e54361.png">

**After**
<img width="1301" alt="Screenshot 2022-06-21 at 12 14 10" src="https://user-images.githubusercontent.com/106440100/174763778-351bb2d5-6449-43a0-a104-470599125c9d.png">
